### PR TITLE
Optimized logs writting and added locks for safety

### DIFF
--- a/elysiandb.go
+++ b/elysiandb.go
@@ -27,11 +27,11 @@ func main() {
 
 	globals.SetConfig(cfg)
 
-	log.Info("Using data folder: ", globals.GetConfig().Store.Folder)
+	log.DirectInfo("Using data folder: ", globals.GetConfig().Store.Folder)
 
 	boot.InitDB()
 
-	log.Info("Ready to serve your key-value needs with elegance.")
+	log.DirectInfo("Ready to serve your key-value needs with elegance.")
 
 	if cfg.Server.HTTP.Enabled {
 		go boot.StartHTTP()

--- a/internal/boot/log.go
+++ b/internal/boot/log.go
@@ -17,10 +17,7 @@ func BootLogger() {
 
 func WriteLogsPeriodically(interval time.Duration) {
 	for {
-		if len(log.Logs) > 0 {
-			log.WriteLogs()
-		}
-
+		log.WriteLogs()
 		time.Sleep(interval)
 	}
 }

--- a/internal/boot/server.go
+++ b/internal/boot/server.go
@@ -31,7 +31,7 @@ func StartHTTP() {
 		NoDefaultServerHeader: true,
 	}
 
-	log.Info("ElysianDB HTTP listening on http://", addr)
+	log.DirectInfo("ElysianDB HTTP listening on http://", addr)
 	if err := srv.ListenAndServe(addr); err != nil {
 		log.Fatal("server error: ", err)
 	}

--- a/internal/boot/tcp.go
+++ b/internal/boot/tcp.go
@@ -20,7 +20,7 @@ func InitTCP() {
 	}
 	defer ln.Close()
 
-	log.Info("TCP server listening on", addr)
+	log.DirectInfo("TCP server listening on", addr)
 
 	for {
 		tc, err := ln.AcceptTCP()


### PR DESCRIPTION
### Summary

This PR improves the logging system by making it concurrency-safe and more efficient.

### Changes
- Replaced the global `[]string` logs buffer with a `LogsContainer` protected by `sync.Mutex`.
- Removed goroutines for each log call to avoid excessive goroutine creation under load.
- Updated `Fatal` to print errors using `%v` (safer for non-string errors).
- Optimized `WriteLogs`:
  - Perform a safe swap of the logs slice under lock.
  - Print logs after unlocking to avoid blocking writers.
  - Reset slice with `[:0]` to reuse capacity and reduce GC pressure.
 - Added direct info log to have boot info instantly, not to presume that it has not started yet

### Benefits
- Thread-safe log storage and flushing.
- Lower CPU and memory overhead under high throughput.
- Clearer and more reliable error output.

### Notes
This change does not affect the external API of the logger. All existing calls (`Info`, `Warn`, `Error`, etc.) continue to work as before.
