### PR TITLE
Add basic HTTP E2E tests and CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  test:
+    name: Go tests
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version: ["1.23.x"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+          cache: true
+
+      - name: Verify go.mod
+        run: go mod tidy && git diff --exit-code
+
+      - name: Run tests (race)
+        run: make test
+
+      - name: Coverage
+        run: go test ./... -race -coverprofile=coverage.out -count=1
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ matrix.go-version }}
+          path: coverage.out

--- a/Makefile
+++ b/Makefile
@@ -2,3 +2,28 @@ tcp_benchmark:
 	./elysian_bench -addr 127.0.0.1:8088   -vus 500 -duration 20s -keys 20000 -payload 16 -pair
 http_benchmark:
 	./benchmark.sh
+
+
+.PHONY: test test-e2e-http test-unit test-cover
+
+# Ne lance que les packages qui ont des tests
+test:
+	@pkgs=$$(go list -f '{{if or (len .TestGoFiles) (len .XTestGoFiles)}}{{.ImportPath}}{{end}}' ./... | grep -v '^$$'); \
+	if [ -z "$$pkgs" ]; then echo "no test packages"; exit 0; fi; \
+	go test $$pkgs -v -race -count=1
+
+# E2E HTTP uniquement
+test-e2e-http:
+	go test ./test/e2e/http -v -race -count=1
+
+# (optionnel) Unit tests uniquement (exclut test/e2e/*)
+test-unit:
+	@pkgs=$$(go list ./... | grep -v '^github.com/[^/]*/[^/]*/test/'); \
+	if [ -z "$$pkgs" ]; then echo "no unit test packages"; exit 0; fi; \
+	go test $$pkgs -v -race -count=1
+
+# (optionnel) Couverture
+test-cover:
+	@pkgs=$$(go list -f '{{if or (len .TestGoFiles) (len .XTestGoFiles)}}{{.ImportPath}}{{end}}' ./... | grep -v '^$$'); \
+	if [ -z "$$pkgs" ]; then echo "no test packages"; exit 0; fi; \
+	go test $$pkgs -race -coverprofile=coverage.out -count=1 && go tool cover -func=coverage.out

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 </p>
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/taymour/elysiandb.svg)](https://hub.docker.com/r/taymour/elysiandb)
+[![Tests](https://img.shields.io/github/actions/workflow/status/taymour/elysiandb/ci.yml?branch=main&label=tests)](https://github.com/taymour/elysiandb/actions/workflows/ci.yml)
+[![Coverage](https://codecov.io/gh/taymour/elysiandb/branch/main/graph/badge.svg)](https://codecov.io/gh/taymour/elysiandb)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 **ElysianDB** is a lightweight, high-performance key–value store written in Go. It supports **TCP and HTTP protocols**, combining a minimal Redis-style text protocol with a simple REST interface. Designed to be fast, easy to configure, and resource-efficient, ElysianDB offers persistence, TTL support, and straightforward deployment via Docker.

--- a/go.mod
+++ b/go.mod
@@ -5,12 +5,15 @@ go 1.23.0
 toolchain go1.24.7
 
 require (
+	github.com/cespare/xxhash/v2 v2.3.0
+	github.com/fasthttp/router v1.5.4
+	github.com/valyala/fasthttp v1.65.0
+	gopkg.in/yaml.v2 v2.4.0
+)
+
+require (
 	github.com/andybalholm/brotli v1.2.0 // indirect
-	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/fasthttp/router v1.5.4 // indirect
 	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/savsgio/gotils v0.0.0-20240704082632-aef3928b8a38 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
-	github.com/valyala/fasthttp v1.65.0 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,5 @@
 github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=
 github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
-github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/fasthttp/router v1.5.4 h1:oxdThbBwQgsDIYZ3wR1IavsNl6ZS9WdjKukeMikOnC8=
@@ -13,6 +12,9 @@ github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6Kllzaw
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasthttp v1.65.0 h1:j/u3uzFEGFfRxw79iYzJN+TteTJwbYkru9uDp3d0Yf8=
 github.com/valyala/fasthttp v1.65.0/go.mod h1:P/93/YkKPMsKSnATEeELUCkG8a7Y+k99uxNHVbKINr4=
+github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZqKjWU=
+github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/test/e2e/http/controller_test.go
+++ b/test/e2e/http/controller_test.go
@@ -1,0 +1,97 @@
+package e2e
+
+import (
+	"testing"
+	"time"
+
+	"github.com/valyala/fasthttp"
+)
+
+func TestPUTAndGET(t *testing.T) {
+	client, stop := startTestServer(t)
+	defer stop()
+
+	req := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseRequest(req)
+	defer fasthttp.ReleaseResponse(resp)
+
+	req.Header.SetMethod(fasthttp.MethodPut)
+	req.SetRequestURI("http://test/kv/foo")
+	req.SetBodyString("bar")
+
+	if err := client.Do(req, resp); err != nil {
+		t.Fatalf("PUT failed: %v", err)
+	}
+	if sc := resp.StatusCode(); sc != fasthttp.StatusNoContent {
+		t.Fatalf("expected 204, got %d", sc)
+	}
+
+	req.Reset()
+	resp.Reset()
+	req.Header.SetMethod(fasthttp.MethodGet)
+	req.SetRequestURI("http://test/kv/foo")
+
+	if err := client.Do(req, resp); err != nil {
+		t.Fatalf("GET failed: %v", err)
+	}
+	if sc := resp.StatusCode(); sc != fasthttp.StatusOK {
+		t.Fatalf("expected 200, got %d", sc)
+	}
+	if string(resp.Body()) != "bar" {
+		t.Fatalf("expected body 'bar', got %q", resp.Body())
+	}
+}
+
+func TestPUTWithTTLExpires(t *testing.T) {
+	client, stop := startTestServer(t)
+	defer stop()
+
+	req := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseRequest(req)
+	defer fasthttp.ReleaseResponse(resp)
+
+	req.Header.SetMethod(fasthttp.MethodPut)
+	req.SetRequestURI("http://test/kv/ephemeral?ttl=1")
+	req.SetBodyString("tmp")
+	if err := client.Do(req, resp); err != nil {
+		t.Fatalf("put failed: %v", err)
+	}
+	if resp.StatusCode() != 204 {
+		t.Fatalf("expected 204, got %d", resp.StatusCode())
+	}
+
+	time.Sleep(1100 * time.Millisecond)
+
+	req.Reset()
+	resp.Reset()
+	req.Header.SetMethod(fasthttp.MethodGet)
+	req.SetRequestURI("http://test/kv/ephemeral")
+	if err := client.Do(req, resp); err != nil {
+		t.Fatalf("get failed: %v", err)
+	}
+	if resp.StatusCode() != 404 {
+		t.Fatalf("expected 404 after TTL, got %d", resp.StatusCode())
+	}
+}
+
+func TestGETNotFound(t *testing.T) {
+	client, stop := startTestServer(t)
+	defer stop()
+
+	req := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseRequest(req)
+	defer fasthttp.ReleaseResponse(resp)
+
+	req.Header.SetMethod(fasthttp.MethodGet)
+	req.SetRequestURI("http://test/kv/notfound")
+
+	if err := client.Do(req, resp); err != nil {
+		t.Fatalf("GET failed: %v", err)
+	}
+	if resp.StatusCode() != fasthttp.StatusNotFound {
+		t.Fatalf("expected 404 for missing key, got %d", resp.StatusCode())
+	}
+}

--- a/test/e2e/http/server_test.go
+++ b/test/e2e/http/server_test.go
@@ -1,0 +1,45 @@
+package e2e
+
+import (
+	"net"
+	"testing"
+
+	"github.com/fasthttp/router"
+	"github.com/taymour/elysiandb/internal/configuration"
+	"github.com/taymour/elysiandb/internal/globals"
+	"github.com/taymour/elysiandb/internal/routing"
+	"github.com/taymour/elysiandb/internal/storage"
+	"github.com/valyala/fasthttp"
+	"github.com/valyala/fasthttp/fasthttputil"
+)
+
+func startTestServer(t *testing.T) (*fasthttp.Client, func()) {
+	t.Helper()
+
+	tmp := t.TempDir()
+	cfg := &configuration.Config{
+		Store: configuration.StoreConfig{
+			Folder: tmp,
+			Shards: 8,
+		},
+	}
+	globals.SetConfig(cfg)
+	storage.LoadDB()
+
+	r := router.New()
+	routing.RegisterRoutes(r)
+	srv := &fasthttp.Server{Handler: r.Handler}
+
+	ln := fasthttputil.NewInmemoryListener()
+	go func() { _ = srv.Serve(ln) }()
+
+	client := &fasthttp.Client{
+		Dial: func(addr string) (net.Conn, error) { return ln.Dial() },
+	}
+
+	teardown := func() {
+		_ = ln.Close()
+		_ = srv.Shutdown()
+	}
+	return client, teardown
+}


### PR DESCRIPTION
Introduce minimal end‑to‑end tests for the HTTP API and enable GitHub Actions to run make test on push/PR. Keeps scope tight and non‑intrusive.