### PR TITLE
Added tests & read/write db made safer

### DIFF
--- a/internal/globals/globals.go
+++ b/internal/globals/globals.go
@@ -1,15 +1,26 @@
 package globals
 
-import "github.com/taymour/elysiandb/internal/configuration"
+import (
+	"sync"
+
+	"github.com/taymour/elysiandb/internal/configuration"
+)
 
 var (
+	mu  sync.RWMutex
 	cfg *configuration.Config
 )
 
 func SetConfig(c *configuration.Config) {
+	mu.Lock()
 	cfg = c
+	mu.Unlock()
 }
 
 func GetConfig() *configuration.Config {
-	return cfg
+	mu.RLock()
+	c := cfg
+	mu.RUnlock()
+
+	return c
 }

--- a/internal/storage/write.go
+++ b/internal/storage/write.go
@@ -12,11 +12,16 @@ import (
 func WriteToDB() {
 	cfg := globals.GetConfig()
 
-	if err := writeStoreToFile(cfg, DataFile, mainStore); err != nil {
+	rootMu.RLock()
+	ms := mainStore
+	ec := expirationContainer
+	rootMu.RUnlock()
+
+	if err := writeStoreToFile(cfg, DataFile, ms); err != nil {
 		log.Error("Error writing main store to database:", err)
 	}
 
-	if err := writeExpirationsToFile(cfg, ExpirationDataFile, expirationContainer); err != nil {
+	if err := writeExpirationsToFile(cfg, ExpirationDataFile, ec); err != nil {
 		log.Error("Error writing expiration store to database:", err)
 	}
 }

--- a/internal/transport/http/controller/save.go
+++ b/internal/transport/http/controller/save.go
@@ -11,5 +11,5 @@ func SaveController(ctx *fasthttp.RequestCtx) {
 	ctx.SetContentType("application/json")
 	ctx.SetStatusCode(http.StatusNoContent)
 
-	go storage.WriteToDB()
+	storage.WriteToDB()
 }

--- a/test/e2e/http/controller_test.go
+++ b/test/e2e/http/controller_test.go
@@ -95,3 +95,96 @@ func TestGETNotFound(t *testing.T) {
 		t.Fatalf("expected 404 for missing key, got %d", resp.StatusCode())
 	}
 }
+
+func TestPutAndSave(t *testing.T) {
+	client, stop := startTestServer(t)
+	defer stop()
+
+	req := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseRequest(req)
+	defer fasthttp.ReleaseResponse(resp)
+
+	req.Header.SetMethod(fasthttp.MethodPut)
+	req.SetRequestURI("http://test/kv/foo")
+	req.SetBodyString("bar")
+
+	if err := client.Do(req, resp); err != nil {
+		t.Fatalf("PUT failed: %v", err)
+	}
+	if sc := resp.StatusCode(); sc != fasthttp.StatusNoContent {
+		t.Fatalf("expected 204, got %d", sc)
+	}
+
+	req.Reset()
+	resp.Reset()
+	req.Header.SetMethod(fasthttp.MethodPost)
+	req.SetRequestURI("http://test/save")
+
+	if err := client.Do(req, resp); err != nil {
+		t.Fatalf("POST failed: %v", err)
+	}
+	if sc := resp.StatusCode(); sc != fasthttp.StatusNoContent {
+		t.Fatalf("expected 204, got %d", sc)
+	}
+
+	req.Reset()
+	resp.Reset()
+	req.Header.SetMethod(fasthttp.MethodGet)
+	req.SetRequestURI("http://test/kv/foo")
+
+	if err := client.Do(req, resp); err != nil {
+		t.Fatalf("GET failed: %v", err)
+	}
+	if sc := resp.StatusCode(); sc != fasthttp.StatusOK {
+		t.Fatalf("expected 200, got %d", sc)
+	}
+	if string(resp.Body()) != "bar" {
+		t.Fatalf("expected body 'bar', got %q", resp.Body())
+	}
+}
+
+func TestPutAndReset(t *testing.T) {
+	client, stop := startTestServer(t)
+	defer stop()
+
+	req := fasthttp.AcquireRequest()
+	resp := fasthttp.AcquireResponse()
+	defer fasthttp.ReleaseRequest(req)
+	defer fasthttp.ReleaseResponse(resp)
+
+	req.Header.SetMethod(fasthttp.MethodPut)
+	req.SetRequestURI("http://test/kv/foo2")
+	req.SetBodyString("bar")
+
+	if err := client.Do(req, resp); err != nil {
+		t.Fatalf("PUT failed: %v", err)
+	}
+	if sc := resp.StatusCode(); sc != fasthttp.StatusNoContent {
+		t.Fatalf("expected 204, got %d", sc)
+	}
+
+	req.Reset()
+	resp.Reset()
+	req.Header.SetMethod(fasthttp.MethodPost)
+	req.SetRequestURI("http://test/reset")
+
+	if err := client.Do(req, resp); err != nil {
+		t.Fatalf("POST failed: %v", err)
+	}
+	if sc := resp.StatusCode(); sc != fasthttp.StatusOK {
+		t.Fatalf("expected 200, got %d", sc)
+	}
+
+	req.Reset()
+	resp.Reset()
+	req.Header.SetMethod(fasthttp.MethodGet)
+	req.SetRequestURI("http://test/kv/foo2")
+
+	if err := client.Do(req, resp); err != nil {
+		t.Fatalf("GET failed: %v", err)
+	}
+	if resp.StatusCode() != fasthttp.StatusNotFound {
+		t.Fatalf("expected 404 for missing key, got %d", resp.StatusCode())
+	}
+}


### PR DESCRIPTION
## Summary

This PR adds HTTP E2E tests and hardens database read/write (persistence + expirations) to prevent data races observed during saves.

## Key changes

* **Tests:** add HTTP E2E tests covering PUT/GET, TTL expiration, SAVE, and RESET.
* **Synchronous SAVE:** `SaveController` now calls `storage.WriteToDB()` **synchronously** (no goroutine) to avoid overlap with test restarts.
* **Root storage lock:** introduce a `rootMu (RWMutex)` to protect **swapping** of global pointers (`mainStore`, `expirationContainer`) and to **snapshot** them when writing to disk.
* **Thread‑safe globals:** wrap `globals.SetConfig` / `GetConfig` with an `RWMutex`.

## Why

* Fixes a **data race** between async DB save and store reload during tests.
* Ensures global pointers are not replaced while a save is in progress.

## Review notes

* Locks are applied at the **root** (pointer) level; existing fine‑grained locks inside structures remain unchanged.
* Functional behavior is unchanged; only the synchronization strategy for persistence is updated.

## Test plan

* `make test` (with `-race`) should pass with no data races.
* E2E tests cover:

  * PUT/GET
  * PUT with TTL and expiration
  * SAVE (persistence)
  * RESET (store cleanup)

## Breaking changes

* No API changes. `SAVE` becomes blocking (synchronous) server‑side; no external impact expected.
